### PR TITLE
Support multiple guestbooks w/difft form names.

### DIFF
--- a/guestbook.php
+++ b/guestbook.php
@@ -205,7 +205,7 @@ class GuestbookPlugin extends Plugin
 
     private function approveAll()
     {
-        $filename = DATA_DIR . 'guestbook/' . $this->grav['config']->get('plugins.guestbook.filename');
+        $filename = DATA_DIR . $this->grav['page']->header()->form['name'] . '/' . $this->grav['config']->get('plugins.guestbook.filename');
         $file = File::instance($filename);
 
         if (!$file->content()) {
@@ -234,12 +234,13 @@ class GuestbookPlugin extends Plugin
             $messages = $checked;
             $yaml = Yaml::dump($messages);
             file_put_contents($filename, $yaml);
+            $file->load();
         }
     }
 
     private function approveMessage($uid)
     {
-        $filename = DATA_DIR . 'guestbook/' . $this->grav['config']->get('plugins.guestbook.filename');
+        $filename = DATA_DIR . $this->grav['page']->header()->form['name'] . '/' . $this->grav['config']->get('plugins.guestbook.filename');
         $file = File::instance($filename);
 
         if (!$file->content()) {
@@ -276,7 +277,7 @@ class GuestbookPlugin extends Plugin
 
     private function deleteMessage($uid)
     {
-        $filename = DATA_DIR . 'guestbook/' . $this->grav['config']->get('plugins.guestbook.filename');
+        $filename = DATA_DIR . $this->grav['page']->header()->form['name'] . '/' . $this->grav['config']->get('plugins.guestbook.filename');
         $file = File::instance($filename);
 
         if (!$file->content()) {
@@ -316,7 +317,7 @@ class GuestbookPlugin extends Plugin
         $itemsPerPage = 5;
 
         $lang = $this->grav['language']->getActive();
-        $filename = DATA_DIR . 'guestbook/' . $this->grav['config']->get('plugins.guestbook.filename');
+        $filename = DATA_DIR . $this->grav['page']->header()->form['name'] . '/' . $this->grav['config']->get('plugins.guestbook.filename');
         $file = File::instance($filename);
 
         if (!$file->content()) {


### PR DESCRIPTION
Instead of hard-coding the data directory as "guestbook/", use the name of the form in the page.  Form saves are handled by the Form plugin that already saves to a data directory with the same name as the form.  This just allows guestbook getMessages and approveAll to use that file that is created.  

The file->load() was added in approveAll, because without it getMessages goes into an infinite recursion when the first message is saved (apparently because it is using File::instance which must have some caching, but this Approval write is happening outside of the instance). I couldn't figure out how to test/exercise the approveMessage or deleteMessage functions, but i made the same change there too.